### PR TITLE
Fix modularity test

### DIFF
--- a/src/test/java/com/riderguru/rider_guru/ApplicationModularityTests.java
+++ b/src/test/java/com/riderguru/rider_guru/ApplicationModularityTests.java
@@ -1,6 +1,7 @@
 package com.riderguru.rider_guru;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.modulith.core.ApplicationModules;
 
 class ApplicationModularityTests {
@@ -9,6 +10,8 @@ class ApplicationModularityTests {
     void bootstrapApplicationModules() {
         var modules = ApplicationModules.of(RiderGuruApplication.class);
 
-		System.out.println(modules);    }
+        modules.verify();
+        Assertions.assertFalse(modules.stream().count() == 0);
+    }
 
 }


### PR DESCRIPTION
## Summary
- add Assertions to modularity test
- verify the application modules and assert at least one module exists
- remove printing to stdout

## Testing
- `./mvnw test -q` *(fails: cannot fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_68735d3310e48324a6e9234390a232d3