### PR TITLE
Remove leftover try-catch in PaymentService

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentService.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentService.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
-import java.text.ParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,12 +55,7 @@ class PaymentService implements GenericService<Payment> {
             log.info("No criteria provided");
             return Collections.emptyList();
         }
-        Specification<Payment> spec = null;
-//        try {
-            spec = Specification.where(PaymentSpecification.hasRazorpayId(params.get("razorpayId")));
-//        } catch (ParseException e) {
-//            throw new RuntimeException(e);
-//        }
+        Specification<Payment> spec = Specification.where(PaymentSpecification.hasRazorpayId(params.get("razorpayId")));
         List<Payment> payments = paymentRepository.findAll(spec);
         log.info("Payment found : {}", !payments.isEmpty());
         return payments;


### PR DESCRIPTION
## Summary
- clean `PaymentService` by removing commented `try`/`catch`
- drop unused `ParseException` import

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68735d321b0c832485d460d3bb721f40