### PR TITLE
Externalize secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Rider Guru
+
+This project requires external configuration for secrets such as database credentials and API keys. Provide the following environment variables or configuration properties when running the application:
+
+- `DB_URL` – JDBC connection URL for the database
+- `DB_USERNAME` – database user name
+- `DB_PASSWORD` – database password
+- `RABBITMQ_USERNAME` – RabbitMQ user name
+- `RABBITMQ_PASSWORD` – RabbitMQ password
+- `GOOGLE_MAP_KEY` – Google Maps API key
+- `RAZORPAY_API_KEY` – Razorpay API key
+- `RAZORPAY_API_SECRET` – Razorpay API secret
+
+These values can be supplied as environment variables, command line arguments, or in an external `application.properties` file.

--- a/src/main/java/com/riderguru/rider_guru/payment/internal/RazorpayAdapter.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/internal/RazorpayAdapter.java
@@ -3,6 +3,7 @@ package com.riderguru.rider_guru.payment.internal;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -23,9 +24,17 @@ class RazorpayAdapter {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
-    RazorpayAdapter(RestTemplate restTemplate, ObjectMapper objectMapper) {
+    private final String apiKey;
+    private final String apiSecret;
+
+    RazorpayAdapter(RestTemplate restTemplate,
+                   ObjectMapper objectMapper,
+                   @Value("${razorpay.api.key}") String apiKey,
+                   @Value("${razorpay.api.secret}") String apiSecret) {
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.apiSecret = apiSecret;
     }
 
     public Map<String, Object> createPaymentLink(Map<String, Object> paymentLinkRequest) {
@@ -51,8 +60,6 @@ class RazorpayAdapter {
     }
 
     private String getBasicAuth() {
-        String apiKey = "rzp_test_mw2iyETt0Pr6Lr";
-        String apiSecret = "9ByQyTfoPzMeB2YADOcNiTTy";
         String auth = apiKey + ":" + apiSecret;
         return Base64.getEncoder().encodeToString(auth.getBytes());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,13 +21,16 @@ management.endpoints.web.exposure.include="*"
 #spring.datasource.password=secret
 #spring.datasource.username=myuser
 #spring.datasource.url=jdbc:mysql://localhost:3306/mydatabase
-spring.datasource.password=UjweBFe7Ac
-spring.datasource.username=sql12750853
-spring.datasource.url=jdbc:mysql://sql12.freesqldatabase.com:3306/sql12750853
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.url=${DB_URL}
 
-spring.rabbitmq.password=secret
-spring.rabbitmq.username=myuser
+spring.rabbitmq.password=${RABBITMQ_PASSWORD}
+spring.rabbitmq.username=${RABBITMQ_USERNAME}
 
 #spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_URL:http://localhost:7070}/realms/RiderGuru
 
-google.map.key=AIzaSyA-GajMFLYHyhT-EjhZWCSajaRTSRyzYBI
+google.map.key=${GOOGLE_MAP_KEY}
+
+razorpay.api.key=${RAZORPAY_API_KEY}
+razorpay.api.secret=${RAZORPAY_API_SECRET}


### PR DESCRIPTION
## Summary
- move credentials out of application.properties
- read Razorpay API credentials from configuration
- document required environment variables

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_68735d76be5c832482985325bbca5d53