### PR TITLE
Add notification query support

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/gateway/GatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/GatewayHandler.java
@@ -8,6 +8,7 @@ import com.riderguru.rider_guru.map.LocationDto;
 import com.riderguru.rider_guru.map.MapsAPI;
 import com.riderguru.rider_guru.map.PlaceDto;
 import com.riderguru.rider_guru.notification.NotificationsAPI;
+import com.riderguru.rider_guru.notification.NotificationDto;
 import com.riderguru.rider_guru.payment.PaymentDto;
 import com.riderguru.rider_guru.payment.PaymentsAPI;
 import com.riderguru.rider_guru.trips.TripDto;
@@ -137,6 +138,11 @@ public class GatewayHandler {
     @GetMapping("/notifications/otp/verify")
     public ResponseEntity<Boolean> verifyOtp(@RequestParam("otp") String otp) {
         return notificationsAPI.verifyOtp(otp);
+    }
+
+    @GetMapping("/notifications/query")
+    public ResponseEntity<List<NotificationDto>> queryNotifications(@RequestParam(required = false) Map<String, String> params) {
+        return notificationsAPI.query(params);
     }
 
     @PostMapping("/payments/create")

--- a/src/main/java/com/riderguru/rider_guru/notification/NotificationDto.java
+++ b/src/main/java/com/riderguru/rider_guru/notification/NotificationDto.java
@@ -11,4 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class NotificationDto {
     private Long id;
+    private Long userId;
+    private String message;
+    private String status;
+    private java.time.LocalDateTime createdAt;
 }

--- a/src/main/java/com/riderguru/rider_guru/notification/internal/Notification.java
+++ b/src/main/java/com/riderguru/rider_guru/notification/internal/Notification.java
@@ -16,4 +16,17 @@ class Notification {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "message")
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private NotificationStatus status;
+
+    @Column(name = "created_at")
+    private java.time.LocalDateTime createdAt;
 }

--- a/src/main/java/com/riderguru/rider_guru/notification/internal/NotificationHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/notification/internal/NotificationHandler.java
@@ -8,43 +8,65 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 
+
 @Component
 class NotificationHandler implements NotificationsAPI {
 
     private final NotificationService notificationService;
+    private final NotificationMapper notificationMapper;
 
-    NotificationHandler(NotificationService notificationService) {
+    NotificationHandler(NotificationService notificationService, NotificationMapper notificationMapper) {
         this.notificationService = notificationService;
+        this.notificationMapper = notificationMapper;
     }
 
     @Override
     public ResponseEntity<NotificationDto> create(NotificationDto notificationDto) {
-        return null;
+        Notification notification = notificationService.save(notificationMapper.toEntity(notificationDto));
+        return ResponseEntity.ok(notificationMapper.toDto(notification));
     }
 
     @Override
     public ResponseEntity<NotificationDto> getById(Long id) {
-        return null;
+        return notificationService.getById(id)
+                .map(n -> ResponseEntity.ok(notificationMapper.toDto(n)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @Override
     public ResponseEntity<List<NotificationDto>> getAll() {
-        return null;
+        return ResponseEntity.ok(notificationService.getAll()
+                .stream()
+                .map(notificationMapper::toDto)
+                .toList());
     }
 
     @Override
     public ResponseEntity<NotificationDto> delete(Long id) {
-        return null;
+        return notificationService.getById(id)
+                .map(n -> {
+                    notificationService.delete(id);
+                    return ResponseEntity.ok(notificationMapper.toDto(n));
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @Override
     public ResponseEntity<List<NotificationDto>> query(Map<String, String> params) {
-        return null;
+        return ResponseEntity.ok(notificationService.query(params)
+                .stream()
+                .map(notificationMapper::toDto)
+                .toList());
     }
 
     @Override
     public ResponseEntity<NotificationDto> update(NotificationDto notificationDto) {
-        return null;
+        return notificationService.getById(notificationDto.getId())
+                .map(n -> {
+                    Notification saved = notificationService.save(notificationMapper.toEntity(notificationDto));
+                    return ResponseEntity.ok(notificationMapper.toDto(saved));
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @Override

--- a/src/main/java/com/riderguru/rider_guru/notification/internal/NotificationSpecification.java
+++ b/src/main/java/com/riderguru/rider_guru/notification/internal/NotificationSpecification.java
@@ -1,0 +1,16 @@
+package com.riderguru.rider_guru.notification.internal;
+
+import org.springframework.data.jpa.domain.Specification;
+
+class NotificationSpecification {
+
+    public static Specification<Notification> hasUserId(Long userId) {
+        return (root, query, criteriaBuilder) ->
+                userId != null ? criteriaBuilder.equal(root.get("userId"), userId) : null;
+    }
+
+    public static Specification<Notification> hasStatus(NotificationStatus status) {
+        return (root, query, criteriaBuilder) ->
+                status != null ? criteriaBuilder.equal(root.get("status"), status) : null;
+    }
+}

--- a/src/main/java/com/riderguru/rider_guru/notification/internal/NotificationStatus.java
+++ b/src/main/java/com/riderguru/rider_guru/notification/internal/NotificationStatus.java
@@ -1,0 +1,6 @@
+package com.riderguru.rider_guru.notification.internal;
+
+public enum NotificationStatus {
+    READ,
+    UNREAD
+}


### PR DESCRIPTION
## Summary
- extend `Notification` entity with user, message, status and timestamp
- add `NotificationStatus` enum and `NotificationSpecification`
- implement filtering and sorting in `NotificationService`
- implement CRUD logic in `NotificationHandler`
- expose `/api/notifications/query` endpoint
- update DTO for new fields

## Testing
- `mvn test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_687360fa8c848324bf977f3d37e95b51