### PR TITLE
Add user ID filtering for trips

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/trips/TripDto.java
+++ b/src/main/java/com/riderguru/rider_guru/trips/TripDto.java
@@ -23,4 +23,5 @@ public class TripDto {
     private LocalDateTime scheduledEndTime;
     private LocalDateTime actualEndTime;
     private Boolean isActive;
+    private Long userId;
 }

--- a/src/main/java/com/riderguru/rider_guru/trips/internal/Trip.java
+++ b/src/main/java/com/riderguru/rider_guru/trips/internal/Trip.java
@@ -38,4 +38,6 @@ class Trip {
     private LocalDateTime actualEndTime;
     @Column(name = "is_active")
     private Boolean isActive;
+    @Column(name = "user_id")
+    private Long userId;
 }

--- a/src/main/java/com/riderguru/rider_guru/trips/internal/TripService.java
+++ b/src/main/java/com/riderguru/rider_guru/trips/internal/TripService.java
@@ -63,14 +63,17 @@ class TripService implements GenericService<Trip> {
             log.info("No criteria provided");
             return Collections.emptyList();
         }
-        Specification<Trip> spec = Specification.where(TripSpecification.hasTitle(params.get("title")))
+        Long userId = parseLong(params.get("userId"));
+
+        Specification<Trip> spec = Specification.where(TripSpecification.hasUserId(userId))
+                .and(TripSpecification.hasTitle(params.get("title")))
                 .and(TripSpecification.hasStartPointName(params.get("startPointName")))
                 .and(TripSpecification.hasEndPointName(params.get("endPointName")))
-                .and(TripSpecification.hasScheduledStartTime(LocalDateTime.parse(params.get("scheduledStartTime"))))
-                .and(TripSpecification.hasActualStartTime(LocalDateTime.parse(params.get("actualStartTime"))))
-                .and(TripSpecification.hasScheduledEndTime(LocalDateTime.parse(params.get("scheduledEndTime"))))
-                .and(TripSpecification.hasActualEndTime(LocalDateTime.parse(params.get("actualEndTime"))))
-                .and(TripSpecification.isActive(Boolean.parseBoolean(params.get("isActive"))));
+                .and(TripSpecification.hasScheduledStartTime(parseLocalDateTime(params.get("scheduledStartTime"))))
+                .and(TripSpecification.hasActualStartTime(parseLocalDateTime(params.get("actualStartTime"))))
+                .and(TripSpecification.hasScheduledEndTime(parseLocalDateTime(params.get("scheduledEndTime"))))
+                .and(TripSpecification.hasActualEndTime(parseLocalDateTime(params.get("actualEndTime"))))
+                .and(TripSpecification.isActive(parseBoolean(params.get("isActive"))));
         List<Trip> trips = tripRepository.findAll(spec);
         log.info("Trips found : {}", trips.size());
         return trips;
@@ -81,5 +84,9 @@ class TripService implements GenericService<Trip> {
 
     private Boolean parseBoolean(String booleanStr) {
         return StringUtils.hasText(booleanStr) ? Boolean.parseBoolean(booleanStr) : null;
+    }
+
+    private Long parseLong(String value) {
+        return StringUtils.hasText(value) ? Long.parseLong(value) : null;
     }
 }

--- a/src/main/java/com/riderguru/rider_guru/trips/internal/TripSpecification.java
+++ b/src/main/java/com/riderguru/rider_guru/trips/internal/TripSpecification.java
@@ -7,6 +7,11 @@ import java.time.LocalDateTime;
 
 class TripSpecification {
 
+    public static Specification<Trip> hasUserId(Long userId) {
+        return (root, query, criteriaBuilder) ->
+                userId != null ? criteriaBuilder.equal(root.get("userId"), userId) : null;
+    }
+
     public static Specification<Trip> hasTitle(String title) {
         return (root, query, criteriaBuilder) ->
                 StringUtils.hasText(title) ? criteriaBuilder.equal(root.get("title"), title) : null;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -22,7 +22,8 @@ create table if not exists trips (
     actual_start_time DATETIME NULL,
     scheduled_end_time DATETIME NOT NULL,
     actual_end_time DATETIME NOT NULL,
-    is_active BINARY NOT NULL
+    is_active BINARY NOT NULL,
+    user_id BIGINT NULL
 );
 
 create table if not exists itinerary (


### PR DESCRIPTION
## Summary
- support filtering trips by `userId`
- add `userId` field to Trip entity and DTO
- include userId column in schema

## Testing
- `./mvnw -q test` *(fails: cannot download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6873daaff7248324907ed3c34f22ad14