### PR TITLE
Add user ID in payment records and query

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/payment/PaymentDto.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/PaymentDto.java
@@ -16,6 +16,9 @@ import java.util.Map;
 public class PaymentDto {
     private Long id;
 
+    @JsonProperty("user_id")
+    private Long userId;
+
     @JsonProperty("amount")
     private Integer amount;
 

--- a/src/main/java/com/riderguru/rider_guru/payment/internal/Payment.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/internal/Payment.java
@@ -19,6 +19,9 @@ class Payment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "user_id")
+    private Long userId;
+
     private Integer amount;
     private String currency;
     private Boolean acceptPartial;

--- a/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentHandler.java
@@ -33,6 +33,8 @@ class PaymentHandler implements PaymentsAPI {
         Map<String, Object> razorpayPaymentLinkRequest = razorpayMapper.fromPaymentRequest(savedPaymentRequest);
         Map<String, Object> razorpayPaymentLinkResponse = razorpayAdapter.createPaymentLink(razorpayPaymentLinkRequest);
         PaymentDto razorpayResponse = razorpayMapper.fromRazorpayResponse(razorpayPaymentLinkResponse);
+        razorpayResponse.setId(savedPaymentRequest.getId());
+        razorpayResponse.setUserId(savedPaymentRequest.getUserId());
         PaymentDto savedRazorpayResponse = paymentMapper.toDto(paymentService.save(paymentMapper.toEntity(razorpayResponse)));
         return ResponseEntity.ok(savedRazorpayResponse);
     }

--- a/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentService.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentService.java
@@ -5,6 +5,7 @@ import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -55,9 +56,14 @@ class PaymentService implements GenericService<Payment> {
             log.info("No criteria provided");
             return Collections.emptyList();
         }
-        Specification<Payment> spec = Specification.where(PaymentSpecification.hasRazorpayId(params.get("razorpayId")));
+        Specification<Payment> spec = Specification.where(PaymentSpecification.hasRazorpayId(params.get("razorpayId")))
+                .and(PaymentSpecification.hasUserId(parseLong(params.get("userId"))));
         List<Payment> payments = paymentRepository.findAll(spec);
         log.info("Payment found : {}", !payments.isEmpty());
         return payments;
+    }
+
+    private Long parseLong(String longStr) {
+        return StringUtils.hasText(longStr) ? Long.parseLong(longStr) : null;
     }
 }

--- a/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentSpecification.java
+++ b/src/main/java/com/riderguru/rider_guru/payment/internal/PaymentSpecification.java
@@ -10,4 +10,9 @@ class PaymentSpecification {
                 StringUtils.hasText(razorpayId) ? criteriaBuilder.equal(root.get("razorpayId"), razorpayId) : null;
     }
 
+    public static Specification<Payment> hasUserId(Long userId) {
+        return (root, query, criteriaBuilder) ->
+                userId != null ? criteriaBuilder.equal(root.get("userId"), userId) : null;
+    }
+
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -53,6 +53,7 @@ create table if not exists notifications (
 
 CREATE TABLE if not exists payments (
     id BIGINT AUTO_INCREMENT PRIMARY KEY not null,
+    user_id BIGINT,
     amount INT,
     currency VARCHAR(255),
     accept_partial BOOLEAN,


### PR DESCRIPTION
## Summary
- include `userId` field in payment DTO and entity
- persist user ID in schema
- keep user ID when saving Razorpay response
- add `hasUserId` specification and search by user ID in PaymentService

## Testing
- `mvn test` *(fails: unable to download maven)*

------
https://chatgpt.com/codex/tasks/task_e_6873db383a80832490c859996b8e1336