### PR TITLE
Add basic integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
 			<artifactId>spring-modulith-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/test/java/com/riderguru/rider_guru/trips/internal/TripServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/trips/internal/TripServiceIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.riderguru.rider_guru.trips.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class TripServiceIntegrationTest {
+
+    @Autowired
+    private TripService tripService;
+
+    @Test
+    void saveAndQueryTrip() {
+        LocalDateTime now = LocalDateTime.now();
+        Trip trip = Trip.builder()
+                .title("Test Trip")
+                .startPointName("A")
+                .startLocMap("Amap")
+                .endPointName("B")
+                .endLocMap("Bmap")
+                .scheduledStartTime(now)
+                .actualStartTime(now)
+                .scheduledEndTime(now.plusHours(1))
+                .actualEndTime(now.plusHours(1))
+                .isActive(true)
+                .userId(123L)
+                .build();
+
+        Trip saved = tripService.save(trip);
+        assertNotNull(saved.getId());
+
+        Optional<Trip> found = tripService.getById(saved.getId());
+        assertTrue(found.isPresent());
+
+        Map<String, String> params = Map.of("userId", "123");
+        List<Trip> result = tripService.query(params);
+        assertEquals(1, result.size());
+        assertEquals(saved.getId(), result.get(0).getId());
+    }
+}

--- a/src/test/java/com/riderguru/rider_guru/users/internal/UserServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/users/internal/UserServiceIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.riderguru.rider_guru.users.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void saveAndQueryUser() {
+        User user = User.builder()
+                .name("John")
+                .email("john@example.com")
+                .isEmailVerified(false)
+                .mobileNumber("1234567890")
+                .dob(new Date())
+                .profileImage("img")
+                .sosEmergencyContact("911")
+                .isActive(true)
+                .isPremium(false)
+                .build();
+
+        User saved = userService.save(user);
+        assertNotNull(saved.getId());
+
+        Optional<User> found = userService.getById(saved.getId());
+        assertTrue(found.isPresent());
+
+        Map<String, String> params = Map.of("email", "john@example.com");
+        List<User> result = userService.query(params);
+        assertEquals(1, result.size());
+        assertEquals(saved.getId(), result.get(0).getId());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=always
+google.map.key=dummy
+razorpay.api.key=dummy
+razorpay.api.secret=dummy


### PR DESCRIPTION
## Summary
- add integration tests for `TripService` and `UserService`
- configure test H2 datasource
- include h2 dependency for tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68867299ee548324964a58a89d185803