### PR TITLE
Fix API method calls in gateway handlers

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/gateway/PaymentsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/PaymentsGatewayHandler.java
@@ -38,7 +38,7 @@ public class PaymentsGatewayHandler {
     @PostMapping("/create")
     public ResponseEntity<PaymentDto> createPayment(@Valid @RequestBody PaymentDto paymentDto) {
         logger.info("Received request to create payment: {}", paymentDto);
-        ResponseEntity<PaymentDto> response = paymentsAPI.createPayment(paymentDto);
+        ResponseEntity<PaymentDto> response = paymentsAPI.create(paymentDto);
         logger.info("Response from createPayment: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
@@ -52,7 +52,7 @@ public class PaymentsGatewayHandler {
     @GetMapping("/query")
     public ResponseEntity<List<PaymentDto>> queryPayments(@RequestParam(required = false) Map<String, String> params) {
         logger.info("Received request to query payments with params: {}", params);
-        ResponseEntity<List<PaymentDto>> response = paymentsAPI.queryPayments(params);
+        ResponseEntity<List<PaymentDto>> response = paymentsAPI.query(params);
         logger.info("Response from queryPayments: status={}, body size={}", response.getStatusCode(), response.getBody() != null ? response.getBody().size() : 0);
         return response;
     }

--- a/src/main/java/com/riderguru/rider_guru/gateway/TripsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/TripsGatewayHandler.java
@@ -38,7 +38,7 @@ public class TripsGatewayHandler {
     @PostMapping("/create")
     public ResponseEntity<TripDto> createTrip(@Valid @RequestBody TripDto tripDto) {
         logger.info("Received request to create trip: {}", tripDto);
-        ResponseEntity<TripDto> response = tripsAPI.createTrip(tripDto);
+        ResponseEntity<TripDto> response = tripsAPI.create(tripDto);
         logger.info("Response from createTrip: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
@@ -52,7 +52,7 @@ public class TripsGatewayHandler {
     @PostMapping("/update")
     public ResponseEntity<TripDto> updateTrip(@Valid @RequestBody TripDto tripDto) {
         logger.info("Received request to update trip: {}", tripDto);
-        ResponseEntity<TripDto> response = tripsAPI.updateTrip(tripDto);
+        ResponseEntity<TripDto> response = tripsAPI.update(tripDto);
         logger.info("Response from updateTrip: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
@@ -65,7 +65,7 @@ public class TripsGatewayHandler {
     @GetMapping("/all")
     public ResponseEntity<List<TripDto>> getAllTrips() {
         logger.info("Received request to get all trips");
-        ResponseEntity<List<TripDto>> response = tripsAPI.getAllTrips();
+        ResponseEntity<List<TripDto>> response = tripsAPI.getAll();
         logger.info("Response from getAllTrips: status={}, body size={}", response.getStatusCode(), response.getBody() != null ? response.getBody().size() : 0);
         return response;
     }
@@ -79,7 +79,7 @@ public class TripsGatewayHandler {
     @PostMapping("/delete")
     public ResponseEntity<Void> deleteTrip(@RequestParam Long tripId) {
         logger.info("Received request to delete trip with id: {}", tripId);
-        ResponseEntity<Void> response = tripsAPI.deleteTrip(tripId);
+        ResponseEntity<Void> response = tripsAPI.delete(tripId);
         logger.info("Response from deleteTrip: status={}", response.getStatusCode());
         return response;
     }
@@ -93,7 +93,7 @@ public class TripsGatewayHandler {
     @GetMapping("/query")
     public ResponseEntity<List<TripDto>> queryTrips(@RequestParam(required = false) Map<String, String> params) {
         logger.info("Received request to query trips with params: {}", params);
-        ResponseEntity<List<TripDto>> response = tripsAPI.queryTrips(params);
+        ResponseEntity<List<TripDto>> response = tripsAPI.query(params);
         logger.info("Response from queryTrips: status={}, body size={}", response.getStatusCode(), response.getBody() != null ? response.getBody().size() : 0);
         return response;
     }


### PR DESCRIPTION
## Summary
- update `TripsGatewayHandler` to use `create`, `update`, `getAll`, `delete` and `query` calls from `TripsAPI`
- update `PaymentsGatewayHandler` to use `create` and `query` from `PaymentsAPI`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688676790b648324bfb990e43c310923