### PR TITLE
Add service layer tests

### DIFF
--- a/src/test/java/com/riderguru/rider_guru/itinerary/internal/ItineraryServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/itinerary/internal/ItineraryServiceIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.riderguru.rider_guru.itinerary.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class ItineraryServiceIntegrationTest {
+
+    @Autowired
+    private ItineraryService itineraryService;
+
+    @Test
+    void saveAndFetchItinerary() {
+        LocalDateTime now = LocalDateTime.now();
+        Itinerary itinerary = Itinerary.builder()
+                .eventDescription("Event")
+                .nodalPointName("Node")
+                .nodalPointLocMap("NMap")
+                .nodalPointScheduledTime(now)
+                .nodalPointActualTime(now)
+                .banner("banner")
+                .isActive(true)
+                .tripId(1L)
+                .build();
+
+        Itinerary saved = itineraryService.save(itinerary);
+        assertNotNull(saved.getId());
+
+        Optional<Itinerary> found = itineraryService.getById(saved.getId());
+        assertTrue(found.isPresent());
+
+        List<Itinerary> all = itineraryService.getAll();
+        assertFalse(all.isEmpty());
+    }
+}

--- a/src/test/java/com/riderguru/rider_guru/joining_points/internal/JoiningPointServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/joining_points/internal/JoiningPointServiceIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.riderguru.rider_guru.joining_points.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class JoiningPointServiceIntegrationTest {
+
+    @Autowired
+    private JoiningPointService joiningPointService;
+
+    @Test
+    void saveAndQueryJoiningPoint() {
+        LocalDateTime now = LocalDateTime.now();
+        JoiningPoint jp = JoiningPoint.builder()
+                .joiningPointName("PointA")
+                .joiningPointLocMap("Amap")
+                .scheduledJoiningTime(now)
+                .actualJoiningTime(now)
+                .isActive(true)
+                .tripId(1L)
+                .build();
+
+        JoiningPoint saved = joiningPointService.save(jp);
+        assertNotNull(saved.getId());
+
+        Optional<JoiningPoint> found = joiningPointService.getById(saved.getId());
+        assertTrue(found.isPresent());
+
+        Map<String, String> params = Map.of("joiningPointName", "PointA");
+        List<JoiningPoint> result = joiningPointService.query(params);
+        assertEquals(1, result.size());
+        assertEquals(saved.getId(), result.get(0).getId());
+    }
+}

--- a/src/test/java/com/riderguru/rider_guru/map/internal/MapServiceTest.java
+++ b/src/test/java/com/riderguru/rider_guru/map/internal/MapServiceTest.java
@@ -1,0 +1,46 @@
+package com.riderguru.rider_guru.map.internal;
+
+import com.riderguru.rider_guru.map.LocationDto;
+import com.riderguru.rider_guru.map.PlaceDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MapServiceTest {
+
+    @Mock
+    private MapAdapter mapAdapter;
+
+    @InjectMocks
+    private MapService mapService;
+
+    @Test
+    void searchPlaceDelegatesToAdapter() {
+        List<PlaceDto> places = List.of(new PlaceDto("desc", "pid"));
+        when(mapAdapter.searchPlace("foo")).thenReturn(places);
+
+        List<PlaceDto> result = mapService.searchPlace("foo");
+        assertEquals(places, result);
+    }
+
+    @Test
+    void locationForPlaceIdWrapsException() throws Exception {
+        when(mapAdapter.locationForPlaceId("pid")).thenThrow(new RuntimeException("err"));
+        assertThrows(RuntimeException.class, () -> mapService.locationForPlaceId("pid"));
+    }
+
+    @Test
+    void getRouteDelegatesToAdapter() {
+        when(mapAdapter.getRoute(1.0,2.0,3.0,4.0)).thenReturn("route");
+        String result = mapService.getRoute(1.0,2.0,3.0,4.0);
+        assertEquals("route", result);
+    }
+}

--- a/src/test/java/com/riderguru/rider_guru/notification/internal/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/notification/internal/NotificationServiceIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.riderguru.rider_guru.notification.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class NotificationServiceIntegrationTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Test
+    void saveAndQueryNotification() {
+        Notification notification = Notification.builder()
+                .userId(99L)
+                .message("msg")
+                .status(NotificationStatus.UNREAD)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Notification saved = notificationService.save(notification);
+        assertNotNull(saved.getId());
+
+        Optional<Notification> found = notificationService.getById(saved.getId());
+        assertTrue(found.isPresent());
+
+        Map<String, String> params = Map.of(
+                "userId", "99",
+                "status", "UNREAD"
+        );
+        List<Notification> result = notificationService.query(params);
+        assertEquals(1, result.size());
+        assertEquals(saved.getId(), result.get(0).getId());
+    }
+}

--- a/src/test/java/com/riderguru/rider_guru/payment/internal/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/payment/internal/PaymentServiceIntegrationTest.java
@@ -1,0 +1,43 @@
+package com.riderguru.rider_guru.payment.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class PaymentServiceIntegrationTest {
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Test
+    void saveAndQueryPayment() {
+        Payment payment = Payment.builder()
+                .userId(456L)
+                .amount(1000)
+                .currency("INR")
+                .razorpayId("rpay123")
+                .build();
+
+        Payment saved = paymentService.save(payment);
+        assertNotNull(saved.getId());
+
+        Optional<Payment> found = paymentService.getById(saved.getId());
+        assertTrue(found.isPresent());
+
+        Map<String, String> params = Map.of("userId", "456");
+        List<Payment> result = paymentService.query(params);
+        assertEquals(1, result.size());
+        assertEquals(saved.getId(), result.get(0).getId());
+    }
+}


### PR DESCRIPTION
## Summary
- add integration tests for payment, joining point, itinerary and notification services
- add unit test for map service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688677698370832483ad54e1e615c9da