### PR TITLE
Fix gateway handler method naming

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/gateway/ItineraryGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/ItineraryGatewayHandler.java
@@ -40,7 +40,7 @@ public class ItineraryGatewayHandler {
     }
 
     @GetMapping("/query")
-    public ResponseEntity<List<ItineraryDto>> queryItinerary(@RequestParam(required = false) Map<String, String> params) {
+    public ResponseEntity<List<ItineraryDto>> queryItineraries(@RequestParam(required = false) Map<String, String> params) {
         logger.info("Querying itinerary with params: {}", params);
         ResponseEntity<List<ItineraryDto>> response = itineraryAPI.query(params);
         logger.info("Itinerary query completed with status: {} and result count: {}", response.getStatusCode(),
@@ -49,7 +49,7 @@ public class ItineraryGatewayHandler {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<List<ItineraryDto>> getAllItinerary() {
+    public ResponseEntity<List<ItineraryDto>> getAllItineraries() {
         logger.info("Fetching all itineraries");
         ResponseEntity<List<ItineraryDto>> response = itineraryAPI.getAll();
         logger.info("Fetched {} itineraries", response.getBody() != null ? response.getBody().size() : 0);
@@ -57,10 +57,10 @@ public class ItineraryGatewayHandler {
     }
 
     @DeleteMapping("/delete")
-    public ResponseEntity<Void> deleteItinerary(@RequestParam("itinerary-id") Long itineraryId) {
+    public ResponseEntity<ItineraryDto> deleteItinerary(@RequestParam("itinerary-id") Long itineraryId) {
         logger.info("Deleting itinerary with id: {}", itineraryId);
-        ResponseEntity<Void> response = itineraryAPI.delete(itineraryId);
-        logger.info("Itinerary deletion completed with status: {}", response.getStatusCode());
+        ResponseEntity<ItineraryDto> response = itineraryAPI.delete(itineraryId);
+        logger.info("Itinerary deletion completed with status: {} and body: {}", response.getStatusCode(), response.getBody());
         return response;
     }
 }

--- a/src/main/java/com/riderguru/rider_guru/gateway/JoiningPointsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/JoiningPointsGatewayHandler.java
@@ -57,10 +57,10 @@ public class JoiningPointsGatewayHandler {
     }
 
     @DeleteMapping("/delete")
-    public ResponseEntity<Void> deleteJoiningPoints(@RequestParam("joining-point-id") Long joiningPointId) {
+    public ResponseEntity<JoiningPointsDto> deleteJoiningPoints(@RequestParam("joining-point-id") Long joiningPointId) {
         logger.info("Deleting joining point with id: {}", joiningPointId);
-        ResponseEntity<Void> response = joiningPointsAPI.delete(joiningPointId);
-        logger.info("Joining point deletion finished with status: {}", response.getStatusCode());
+        ResponseEntity<JoiningPointsDto> response = joiningPointsAPI.delete(joiningPointId);
+        logger.info("Joining point deletion finished with status: {} and body: {}", response.getStatusCode(), response.getBody());
         return response;
     }
 }

--- a/src/main/java/com/riderguru/rider_guru/gateway/MapsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/MapsGatewayHandler.java
@@ -47,14 +47,13 @@ public class MapsGatewayHandler {
     }
 
     @GetMapping("/place/route")
-    public ResponseEntity<List<LocationDto>> getRoute(@RequestParam(value = "origin_lat") double originLat,
-                                                     @RequestParam(value = "origin_lng") double originLng,
-                                                     @RequestParam(value = "dest_lat") double destLat,
-                                                     @RequestParam(value = "dest_lng") double destLng) {
+    public ResponseEntity<String> getRoute(@RequestParam(value = "origin_lat") double originLat,
+                                           @RequestParam(value = "origin_lng") double originLng,
+                                           @RequestParam(value = "dest_lat") double destLat,
+                                           @RequestParam(value = "dest_lng") double destLng) {
         logger.info("Calculating route from ({} , {}) to ({} , {})", originLat, originLng, destLat, destLng);
-        ResponseEntity<List<LocationDto>> response = mapsAPI.getRoute(originLat, originLng, destLat, destLng);
-        logger.info("Route calculation finished with status: {} and {} waypoints", response.getStatusCode(),
-                response.getBody() != null ? response.getBody().size() : 0);
+        ResponseEntity<String> response = mapsAPI.getRoute(originLat, originLng, destLat, destLng);
+        logger.info("Route calculation finished with status: {}", response.getStatusCode());
         return response;
     }
 }

--- a/src/main/java/com/riderguru/rider_guru/gateway/NotificationsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/NotificationsGatewayHandler.java
@@ -38,9 +38,9 @@ public class NotificationsGatewayHandler {
      * @return A {@link ResponseEntity} wrapping the downstream response.
      */
     @GetMapping("/otp/send")
-    public ResponseEntity<?> sendOtp(@RequestParam("phone-number") String phoneNumber) {
+    public ResponseEntity<String> sendOtp(@RequestParam("phone-number") String phoneNumber) {
         logger.info("Received request to send OTP for phone number: {}", phoneNumber);
-        ResponseEntity<?> response = notificationsAPI.sendOtp(phoneNumber);
+        ResponseEntity<String> response = notificationsAPI.sendOtp(phoneNumber);
         logger.info("Completed sendOtp call for phone number: {} with status {}", phoneNumber, response.getStatusCode());
         return response;
     }
@@ -52,9 +52,9 @@ public class NotificationsGatewayHandler {
      * @return A {@link ResponseEntity} wrapping the downstream response.
      */
     @GetMapping("/otp/verify")
-    public ResponseEntity<?> verifyOtp(@RequestParam("otp") String otp) {
+    public ResponseEntity<Boolean> verifyOtp(@RequestParam("otp") String otp) {
         logger.info("Received request to verify OTP: {}", otp);
-        ResponseEntity<?> response = notificationsAPI.verifyOtp(otp);
+        ResponseEntity<Boolean> response = notificationsAPI.verifyOtp(otp);
         logger.info("Completed verifyOtp call for OTP: {} with status {}", otp, response.getStatusCode());
         return response;
     }

--- a/src/main/java/com/riderguru/rider_guru/gateway/PaymentsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/PaymentsGatewayHandler.java
@@ -38,7 +38,7 @@ public class PaymentsGatewayHandler {
     @PostMapping("/create")
     public ResponseEntity<PaymentDto> createPayment(@Valid @RequestBody PaymentDto paymentDto) {
         logger.info("Received request to create payment: {}", paymentDto);
-        ResponseEntity<PaymentDto> response = paymentsAPI.createPayment(paymentDto);
+        ResponseEntity<PaymentDto> response = paymentsAPI.create(paymentDto);
         logger.info("Response from createPayment: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
@@ -52,7 +52,7 @@ public class PaymentsGatewayHandler {
     @GetMapping("/query")
     public ResponseEntity<List<PaymentDto>> queryPayments(@RequestParam(required = false) Map<String, String> params) {
         logger.info("Received request to query payments with params: {}", params);
-        ResponseEntity<List<PaymentDto>> response = paymentsAPI.queryPayments(params);
+        ResponseEntity<List<PaymentDto>> response = paymentsAPI.query(params);
         logger.info("Response from queryPayments: status={}, body size={}", response.getStatusCode(), response.getBody() != null ? response.getBody().size() : 0);
         return response;
     }

--- a/src/main/java/com/riderguru/rider_guru/gateway/TripsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/TripsGatewayHandler.java
@@ -38,7 +38,7 @@ public class TripsGatewayHandler {
     @PostMapping("/create")
     public ResponseEntity<TripDto> createTrip(@Valid @RequestBody TripDto tripDto) {
         logger.info("Received request to create trip: {}", tripDto);
-        ResponseEntity<TripDto> response = tripsAPI.createTrip(tripDto);
+        ResponseEntity<TripDto> response = tripsAPI.create(tripDto);
         logger.info("Response from createTrip: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
@@ -52,7 +52,7 @@ public class TripsGatewayHandler {
     @PostMapping("/update")
     public ResponseEntity<TripDto> updateTrip(@Valid @RequestBody TripDto tripDto) {
         logger.info("Received request to update trip: {}", tripDto);
-        ResponseEntity<TripDto> response = tripsAPI.updateTrip(tripDto);
+        ResponseEntity<TripDto> response = tripsAPI.update(tripDto);
         logger.info("Response from updateTrip: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
@@ -65,7 +65,7 @@ public class TripsGatewayHandler {
     @GetMapping("/all")
     public ResponseEntity<List<TripDto>> getAllTrips() {
         logger.info("Received request to get all trips");
-        ResponseEntity<List<TripDto>> response = tripsAPI.getAllTrips();
+        ResponseEntity<List<TripDto>> response = tripsAPI.getAll();
         logger.info("Response from getAllTrips: status={}, body size={}", response.getStatusCode(), response.getBody() != null ? response.getBody().size() : 0);
         return response;
     }
@@ -77,10 +77,10 @@ public class TripsGatewayHandler {
      * @return deletion response entity
      */
     @PostMapping("/delete")
-    public ResponseEntity<Void> deleteTrip(@RequestParam Long tripId) {
+    public ResponseEntity<TripDto> deleteTrip(@RequestParam Long tripId) {
         logger.info("Received request to delete trip with id: {}", tripId);
-        ResponseEntity<Void> response = tripsAPI.deleteTrip(tripId);
-        logger.info("Response from deleteTrip: status={}", response.getStatusCode());
+        ResponseEntity<TripDto> response = tripsAPI.delete(tripId);
+        logger.info("Response from deleteTrip: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
 
@@ -93,7 +93,7 @@ public class TripsGatewayHandler {
     @GetMapping("/query")
     public ResponseEntity<List<TripDto>> queryTrips(@RequestParam(required = false) Map<String, String> params) {
         logger.info("Received request to query trips with params: {}", params);
-        ResponseEntity<List<TripDto>> response = tripsAPI.queryTrips(params);
+        ResponseEntity<List<TripDto>> response = tripsAPI.query(params);
         logger.info("Response from queryTrips: status={}, body size={}", response.getStatusCode(), response.getBody() != null ? response.getBody().size() : 0);
         return response;
     }

--- a/src/main/java/com/riderguru/rider_guru/gateway/UsersGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/UsersGatewayHandler.java
@@ -40,7 +40,7 @@ public class UsersGatewayHandler {
     }
 
     @GetMapping("/query")
-    public ResponseEntity<List<UserDto>> getUser(@RequestParam(required = false) Map<String, String> params) {
+    public ResponseEntity<List<UserDto>> queryUsers(@RequestParam(required = false) Map<String, String> params) {
         logger.info("Querying users with params: {}", params);
         ResponseEntity<List<UserDto>> response = usersAPI.query(params);
         logger.info("User query completed with status: {} and result count: {}", response.getStatusCode(),
@@ -57,10 +57,10 @@ public class UsersGatewayHandler {
     }
 
     @DeleteMapping("/delete")
-    public ResponseEntity<Void> deleteUser(@RequestParam("userid") Long userId) {
+    public ResponseEntity<UserDto> deleteUser(@RequestParam("userid") Long userId) {
         logger.info("Deleting user with id: {}", userId);
-        ResponseEntity<Void> response = usersAPI.delete(userId);
-        logger.info("User deletion finished with status: {}", response.getStatusCode());
+        ResponseEntity<UserDto> response = usersAPI.delete(userId);
+        logger.info("User deletion finished with status: {} and body: {}", response.getStatusCode(), response.getBody());
         return response;
     }
 }


### PR DESCRIPTION
## Summary
- rename itinerary query endpoint method to `queryItineraries`
- rename users query method to `queryUsers`
- keep API call signatures consistent across gateway handlers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688676790b648324bfb990e43c310923