### PR TITLE
Add basic group and messaging support

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/gateway/GroupsGatewayHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/gateway/GroupsGatewayHandler.java
@@ -1,0 +1,54 @@
+package com.riderguru.rider_guru.gateway;
+
+import com.riderguru.rider_guru.groups.*;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups")
+@CrossOrigin("*")
+public class GroupsGatewayHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GroupsGatewayHandler.class);
+
+    private final GroupsAPI groupsAPI;
+
+    public GroupsGatewayHandler(GroupsAPI groupsAPI) {
+        this.groupsAPI = groupsAPI;
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<GroupDto> create(@Valid @RequestBody GroupDto groupDto) {
+        logger.info("Creating group: {}", groupDto.getName());
+        return groupsAPI.create(groupDto);
+    }
+
+    @PostMapping("/{groupId}/members")
+    public ResponseEntity<GroupMemberDto> addMember(@PathVariable Long groupId, @Valid @RequestBody GroupMemberDto memberDto) {
+        logger.info("Adding member {} to group {}", memberDto.getUserId(), groupId);
+        return groupsAPI.addMember(groupId, memberDto);
+    }
+
+    @GetMapping("/{groupId}/members")
+    public ResponseEntity<List<GroupMemberDto>> getMembers(@PathVariable Long groupId) {
+        logger.info("Fetching members for group {}", groupId);
+        return groupsAPI.getMembers(groupId);
+    }
+
+    @PostMapping("/{groupId}/messages")
+    public ResponseEntity<GroupMessageDto> postMessage(@PathVariable Long groupId, @Valid @RequestBody GroupMessageDto messageDto) {
+        logger.info("Posting message in group {}", groupId);
+        return groupsAPI.postMessage(groupId, messageDto);
+    }
+
+    @GetMapping("/{groupId}/messages")
+    public ResponseEntity<List<GroupMessageDto>> getMessages(@PathVariable Long groupId) {
+        logger.info("Fetching messages for group {}", groupId);
+        return groupsAPI.getMessages(groupId);
+    }
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/GroupDto.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/GroupDto.java
@@ -1,0 +1,16 @@
+package com.riderguru.rider_guru.groups;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GroupDto {
+    private Long id;
+    private String name;
+    private Long adminId;
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/GroupMemberDto.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/GroupMemberDto.java
@@ -1,0 +1,16 @@
+package com.riderguru.rider_guru.groups;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GroupMemberDto {
+    private Long id;
+    private Long groupId;
+    private Long userId;
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/GroupMessageDto.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/GroupMessageDto.java
@@ -1,0 +1,20 @@
+package com.riderguru.rider_guru.groups;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GroupMessageDto {
+    private Long id;
+    private Long groupId;
+    private Long senderId;
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/GroupsAPI.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/GroupsAPI.java
@@ -1,0 +1,13 @@
+package com.riderguru.rider_guru.groups;
+
+import com.riderguru.rider_guru.libs.GenericAPI;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface GroupsAPI extends GenericAPI<GroupDto> {
+    ResponseEntity<GroupMemberDto> addMember(Long groupId, GroupMemberDto memberDto);
+    ResponseEntity<List<GroupMemberDto>> getMembers(Long groupId);
+    ResponseEntity<GroupMessageDto> postMessage(Long groupId, GroupMessageDto messageDto);
+    ResponseEntity<List<GroupMessageDto>> getMessages(Long groupId);
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/Group.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/Group.java
@@ -1,0 +1,25 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "groups")
+class Group {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "admin_id")
+    private Long adminId;
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupHandler.java
@@ -1,0 +1,90 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import com.riderguru.rider_guru.groups.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+class GroupHandler implements GroupsAPI {
+
+    private final GroupService groupService;
+    private final GroupMapper groupMapper;
+
+    GroupHandler(GroupService groupService, GroupMapper groupMapper) {
+        this.groupService = groupService;
+        this.groupMapper = groupMapper;
+    }
+
+    @Override
+    public ResponseEntity<GroupDto> create(GroupDto groupDto) {
+        log.info("Creating group: {}", groupDto.getName());
+        Group saved = groupService.save(groupMapper.toEntity(groupDto));
+        return ResponseEntity.ok(groupMapper.toDto(saved));
+    }
+
+    @Override
+    public ResponseEntity<GroupDto> getById(Long id) {
+        return groupService.getById(id)
+                .map(g -> ResponseEntity.ok(groupMapper.toDto(g)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @Override
+    public ResponseEntity<List<GroupDto>> getAll() {
+        return ResponseEntity.ok(groupService.getAll().stream().map(groupMapper::toDto).toList());
+    }
+
+    @Override
+    public ResponseEntity<GroupDto> delete(Long id) {
+        return groupService.getById(id)
+                .map(g -> {
+                    groupService.delete(id);
+                    return ResponseEntity.ok(groupMapper.toDto(g));
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @Override
+    public ResponseEntity<List<GroupDto>> query(java.util.Map<String, String> params) {
+        return ResponseEntity.ok(groupService.query(params).stream().map(groupMapper::toDto).toList());
+    }
+
+    @Override
+    public ResponseEntity<GroupDto> update(GroupDto groupDto) {
+        return groupService.getById(groupDto.getId())
+                .map(g -> ResponseEntity.ok(groupMapper.toDto(groupService.save(groupMapper.toEntity(groupDto)))))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @Override
+    public ResponseEntity<GroupMemberDto> addMember(Long groupId, GroupMemberDto memberDto) {
+        memberDto.setGroupId(groupId);
+        GroupMember saved = groupService.addMember(groupMapper.toEntity(memberDto));
+        return ResponseEntity.ok(groupMapper.toDto(saved));
+    }
+
+    @Override
+    public ResponseEntity<List<GroupMemberDto>> getMembers(Long groupId) {
+        List<GroupMemberDto> members = groupService.getMembers(groupId)
+                .stream().map(groupMapper::toDto).toList();
+        return ResponseEntity.ok(members);
+    }
+
+    @Override
+    public ResponseEntity<GroupMessageDto> postMessage(Long groupId, GroupMessageDto messageDto) {
+        messageDto.setGroupId(groupId);
+        GroupMessage saved = groupService.saveMessage(groupMapper.toEntity(messageDto));
+        return ResponseEntity.ok(groupMapper.toDto(saved));
+    }
+
+    @Override
+    public ResponseEntity<List<GroupMessageDto>> getMessages(Long groupId) {
+        List<GroupMessageDto> messages = groupService.getMessages(groupId)
+                .stream().map(groupMapper::toDto).toList();
+        return ResponseEntity.ok(messages);
+    }
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMapper.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMapper.java
@@ -1,0 +1,71 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import com.riderguru.rider_guru.groups.GroupDto;
+import com.riderguru.rider_guru.groups.GroupMemberDto;
+import com.riderguru.rider_guru.groups.GroupMessageDto;
+import com.riderguru.rider_guru.libs.GenericMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+class GroupMapper implements GenericMapper<Group, GroupDto> {
+
+    @Override
+    public GroupDto toDto(Group e) {
+        if (e == null) return null;
+        return GroupDto.builder()
+                .id(e.getId())
+                .name(e.getName())
+                .adminId(e.getAdminId())
+                .build();
+    }
+
+    @Override
+    public Group toEntity(GroupDto d) {
+        if (d == null) return null;
+        return Group.builder()
+                .id(d.getId())
+                .name(d.getName())
+                .adminId(d.getAdminId())
+                .build();
+    }
+
+    GroupMemberDto toDto(GroupMember e) {
+        if (e == null) return null;
+        return GroupMemberDto.builder()
+                .id(e.getId())
+                .groupId(e.getGroupId())
+                .userId(e.getUserId())
+                .build();
+    }
+
+    GroupMember toEntity(GroupMemberDto d) {
+        if (d == null) return null;
+        return GroupMember.builder()
+                .id(d.getId())
+                .groupId(d.getGroupId())
+                .userId(d.getUserId())
+                .build();
+    }
+
+    GroupMessageDto toDto(GroupMessage e) {
+        if (e == null) return null;
+        return GroupMessageDto.builder()
+                .id(e.getId())
+                .groupId(e.getGroupId())
+                .senderId(e.getSenderId())
+                .message(e.getMessage())
+                .createdAt(e.getCreatedAt())
+                .build();
+    }
+
+    GroupMessage toEntity(GroupMessageDto d) {
+        if (d == null) return null;
+        return GroupMessage.builder()
+                .id(d.getId())
+                .groupId(d.getGroupId())
+                .senderId(d.getSenderId())
+                .message(d.getMessage())
+                .createdAt(d.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMember.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMember.java
@@ -1,0 +1,25 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "group_members")
+class GroupMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id")
+    private Long groupId;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMemberRepository.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMemberRepository.java
@@ -1,0 +1,11 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    List<GroupMember> findByGroupId(Long groupId);
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMessage.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMessage.java
@@ -1,0 +1,33 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "group_messages")
+class GroupMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id")
+    private Long groupId;
+
+    @Column(name = "sender_id")
+    private Long senderId;
+
+    @Column(name = "message")
+    private String message;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMessageRepository.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupMessageRepository.java
@@ -1,0 +1,11 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+interface GroupMessageRepository extends JpaRepository<GroupMessage, Long> {
+    List<GroupMessage> findByGroupId(Long groupId);
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupRepository.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupRepository.java
@@ -1,0 +1,8 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/riderguru/rider_guru/groups/internal/GroupService.java
+++ b/src/main/java/com/riderguru/rider_guru/groups/internal/GroupService.java
@@ -1,0 +1,69 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import com.riderguru.rider_guru.libs.GenericService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+class GroupService implements GenericService<Group> {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupMessageRepository groupMessageRepository;
+
+    GroupService(GroupRepository groupRepository,
+                 GroupMemberRepository groupMemberRepository,
+                 GroupMessageRepository groupMessageRepository) {
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupMessageRepository = groupMessageRepository;
+    }
+
+    @Override
+    public Group save(Group d) {
+        return groupRepository.save(d);
+    }
+
+    @Override
+    public Optional<Group> getById(Long id) {
+        return groupRepository.findById(id);
+    }
+
+    @Override
+    public void delete(Long id) {
+        groupRepository.deleteById(id);
+    }
+
+    @Override
+    public List<Group> getAll() {
+        return groupRepository.findAll();
+    }
+
+    @Override
+    public List<Group> query(Map<String, String> params) {
+        return groupRepository.findAll();
+    }
+
+    GroupMember addMember(GroupMember member) {
+        return groupMemberRepository.save(member);
+    }
+
+    List<GroupMember> getMembers(Long groupId) {
+        return groupMemberRepository.findByGroupId(groupId);
+    }
+
+    GroupMessage saveMessage(GroupMessage message) {
+        if (message.getCreatedAt() == null) {
+            message.setCreatedAt(LocalDateTime.now());
+        }
+        return groupMessageRepository.save(message);
+    }
+
+    List<GroupMessage> getMessages(Long groupId) {
+        return groupMessageRepository.findByGroupId(groupId);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -82,3 +82,23 @@ CREATE TABLE if not exists payments (
     whatsapp_link BOOLEAN,
     razorpay_id VARCHAR(255)
 );
+
+create table if not exists groups (
+  id serial primary key not null,
+  name varchar(100) not null,
+  admin_id bigint not null
+);
+
+create table if not exists group_members (
+  id serial primary key not null,
+  group_id bigint not null,
+  user_id bigint not null
+);
+
+create table if not exists group_messages (
+  id serial primary key not null,
+  group_id bigint not null,
+  sender_id bigint not null,
+  message text not null,
+  created_at datetime not null
+);

--- a/src/test/java/com/riderguru/rider_guru/groups/internal/GroupServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/groups/internal/GroupServiceIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.riderguru.rider_guru.groups.internal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+class GroupServiceIntegrationTest {
+
+    @Autowired
+    private GroupService groupService;
+
+    @Test
+    void createGroupAddMemberAndMessage() {
+        Group group = Group.builder()
+                .name("Test Group")
+                .adminId(1L)
+                .build();
+        Group savedGroup = groupService.save(group);
+        assertNotNull(savedGroup.getId());
+
+        GroupMember member = GroupMember.builder()
+                .groupId(savedGroup.getId())
+                .userId(2L)
+                .build();
+        GroupMember savedMember = groupService.addMember(member);
+        assertNotNull(savedMember.getId());
+        List<GroupMember> members = groupService.getMembers(savedGroup.getId());
+        assertEquals(1, members.size());
+
+        GroupMessage message = GroupMessage.builder()
+                .groupId(savedGroup.getId())
+                .senderId(1L)
+                .message("Hello")
+                .createdAt(LocalDateTime.now())
+                .build();
+        GroupMessage savedMessage = groupService.saveMessage(message);
+        assertNotNull(savedMessage.getId());
+        List<GroupMessage> messages = groupService.getMessages(savedGroup.getId());
+        assertEquals(1, messages.size());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Group, GroupMember, and GroupMessage entities with services and mappers
- expose group creation, membership, and message endpoints
- add initial integration test and database schema for group features

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.riderguru:rider-guru:0.0.1-SNAPSHOT: The following artifacts could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68923736ceb0832488b77f917df06cfd