### PR TITLE
Add user profile background and write-up

### DIFF
--- a/src/main/java/com/riderguru/rider_guru/users/UserDto.java
+++ b/src/main/java/com/riderguru/rider_guru/users/UserDto.java
@@ -24,6 +24,8 @@ public class UserDto {
         @NotNull(message = "Date of Birth needs to be entered")
         private Date dob;
         private String profileImage;
+        private String backgroundImage;
+        private String profileWriteUp;
         private String sosEmergencyContact;
         private Boolean isActive;
         private Boolean isPremium;

--- a/src/main/java/com/riderguru/rider_guru/users/internal/User.java
+++ b/src/main/java/com/riderguru/rider_guru/users/internal/User.java
@@ -30,6 +30,10 @@ class User {
         private Date dob;
         @Column(name = "profile_image")
         private String profileImage;
+        @Column(name = "background_image")
+        private String backgroundImage;
+        @Column(name = "profile_write_up")
+        private String profileWriteUp;
         @Column(name = "sos_emergency_contact")
         private String sosEmergencyContact;
         @Column(name = "is_active")

--- a/src/main/java/com/riderguru/rider_guru/users/internal/UserHandler.java
+++ b/src/main/java/com/riderguru/rider_guru/users/internal/UserHandler.java
@@ -2,6 +2,7 @@ package com.riderguru.rider_guru.users.internal;
 
 import com.riderguru.rider_guru.users.UserDto;
 import com.riderguru.rider_guru.users.UsersAPI;
+import com.riderguru.rider_guru.libs.exceptions.GenericException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -84,6 +85,16 @@ class UserHandler implements UsersAPI {
 
     @Override
     public ResponseEntity<UserDto> update(UserDto userDto) {
-        return null;
+        log.info("Updating user id: {}", userDto.getId());
+        userService.getById(userDto.getId())
+                .orElseThrow(() -> {
+                    String message = "User ID " + userDto.getId() + " not present";
+                    log.error(message);
+                    return new GenericException(message);
+                });
+        ResponseEntity<UserDto> response = ResponseEntity.ok(
+                userMapper.toDto(userService.save(userMapper.toEntity(userDto))));
+        log.info("Update user id {} status: {}", userDto.getId(), response.getStatusCode());
+        return response;
     }
 }

--- a/src/main/java/com/riderguru/rider_guru/users/internal/UserService.java
+++ b/src/main/java/com/riderguru/rider_guru/users/internal/UserService.java
@@ -90,7 +90,7 @@ class UserService implements GenericService<User> {
     /**
      * Queries users based on provided parameters.
      * Supported parameters include email, name, mobileNumber, isEmailVerified, dob, profileImage,
-     * sosEmergencyContact, isActive and isPremium.
+     * backgroundImage, profileWriteUp, sosEmergencyContact, isActive and isPremium.
      *
      * @param params map of query parameters
      * @return list of users matching the criteria
@@ -111,6 +111,8 @@ class UserService implements GenericService<User> {
                     .and(UserSpecification.isEmailVerified(Boolean.parseBoolean(params.get("isEmailVerified"))))
                     .and(UserSpecification.hasDob(new SimpleDateFormat("yyyy-MM-dd").parse(params.get("dob"))))
                     .and(UserSpecification.hasProfileImage(params.get("profileImage")))
+                    .and(UserSpecification.hasBackgroundImage(params.get("backgroundImage")))
+                    .and(UserSpecification.hasProfileWriteUp(params.get("profileWriteUp")))
                     .and(UserSpecification.hasSosEmergencyContact(params.get("sosEmergencyContact")))
                     .and(UserSpecification.isActive(Boolean.parseBoolean(params.get("isActive"))))
                     .and(UserSpecification.isPremium(Boolean.parseBoolean(params.get("isPremium"))));

--- a/src/main/java/com/riderguru/rider_guru/users/internal/UserSpecification.java
+++ b/src/main/java/com/riderguru/rider_guru/users/internal/UserSpecification.java
@@ -37,6 +37,16 @@ class UserSpecification {
                 StringUtils.hasText(profileImage) ? criteriaBuilder.equal(root.get("profileImage"), profileImage) : null;
     }
 
+    public static Specification<User> hasBackgroundImage(String backgroundImage) {
+        return (root, query, criteriaBuilder) ->
+                StringUtils.hasText(backgroundImage) ? criteriaBuilder.equal(root.get("backgroundImage"), backgroundImage) : null;
+    }
+
+    public static Specification<User> hasProfileWriteUp(String profileWriteUp) {
+        return (root, query, criteriaBuilder) ->
+                StringUtils.hasText(profileWriteUp) ? criteriaBuilder.equal(root.get("profileWriteUp"), profileWriteUp) : null;
+    }
+
     public static Specification<User> hasSosEmergencyContact(String sosEmergencyContact) {
         return (root, query, criteriaBuilder) ->
                 StringUtils.hasText(sosEmergencyContact) ? criteriaBuilder.equal(root.get("sosEmergencyContact"), sosEmergencyContact) : null;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,6 +6,8 @@ create table if not exists users (
   mobile_number VARCHAR(15) NOT NULL,
   dob DATE NOT NULL,
   profile_image VARCHAR(100) NULL,
+  background_image VARCHAR(100) NULL,
+  profile_write_up TEXT NULL,
   sos_emergency_contact VARCHAR(15) NULL,
   is_active BINARY NOT NULL,
   is_premium BINARY NOT NULL

--- a/src/test/java/com/riderguru/rider_guru/users/internal/UserServiceIntegrationTest.java
+++ b/src/test/java/com/riderguru/rider_guru/users/internal/UserServiceIntegrationTest.java
@@ -30,6 +30,8 @@ class UserServiceIntegrationTest {
                 .mobileNumber("1234567890")
                 .dob(new Date())
                 .profileImage("img")
+                .backgroundImage("bg")
+                .profileWriteUp("About me")
                 .sosEmergencyContact("911")
                 .isActive(true)
                 .isPremium(false)
@@ -40,8 +42,13 @@ class UserServiceIntegrationTest {
 
         Optional<User> found = userService.getById(saved.getId());
         assertTrue(found.isPresent());
+        assertEquals("bg", found.get().getBackgroundImage());
+        assertEquals("About me", found.get().getProfileWriteUp());
 
-        Map<String, String> params = Map.of("email", "john@example.com");
+        Map<String, String> params = Map.of(
+                "email", "john@example.com",
+                "profileWriteUp", "About me",
+                "backgroundImage", "bg");
         List<User> result = userService.query(params);
         assertEquals(1, result.size());
         assertEquals(saved.getId(), result.get(0).getId());


### PR DESCRIPTION
## Summary
- allow users to store a background image and short profile write-up
- support querying and updating these new profile fields

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68923c3073008324b010e7c9970296b8